### PR TITLE
Added zenmode

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,7 @@
 │ GLOBAL CONTROLS                                                             │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │  q             Quit application                                             │
+│  Ctrl+z        Toggle zen mode (hide sidebar and status bar)                │
 │  Tab           Switch focus between library and reader                      │
 │  Esc           Clear selection, exit search, dismiss popups                 │
 │  Space+h       Toggle reading history popup                                 │

--- a/tests/svg_snapshots.rs
+++ b/tests/svg_snapshots.rs
@@ -155,7 +155,10 @@ fn seed_sample_comments(app: &mut App) {
         updated_at: base_time + chrono::Duration::minutes(5),
     });
 
-    if app.navigate_chapter_relative(ChapterDirection::Next).is_ok() {
+    if app
+        .navigate_chapter_relative(ChapterDirection::Next)
+        .is_ok()
+    {
         if let Some(chapter_b) = app.testing_current_chapter_file() {
             app.testing_add_comment(Comment {
                 chapter_href: chapter_b.clone(),


### PR DESCRIPTION
First of all, I want to thank you for taking the time to create this great app!
The only thing that was (truly) missing for me is a fullscreen/distraction-free/zenmode.
Feel free to change the keybind or the mode's name, it was simply the first name and keybind that came to my mind.

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/5b7e2004-bfcd-4020-a41f-dfc5d87c925a" />

The PR adds a toggleable zen mode that hides the navigation panel and status bar for a distraction-free reading experience.

- Press `Ctrl+z` to toggle zen mode
- Content expands to full screen when active
- Automatically switches focus to content when entering zen mode from navigation panel
- Updated keyboard reference documentation

closes #2 