### PR TITLE
feat(input): Allow up/down arrow keys for navigation

### DIFF
--- a/src/main_app.rs
+++ b/src/main_app.rs
@@ -2491,14 +2491,14 @@ impl App {
                 }
                 true
             }
-            KeyCode::Char('j') => {
+            KeyCode::Char('j') | KeyCode::Down => {
                 let count = self.text_reader.take_count();
                 for _ in 0..count {
                     self.text_reader.normal_mode_down();
                 }
                 true
             }
-            KeyCode::Char('k') => {
+            KeyCode::Char('k') | KeyCode::Up => {
                 let count = self.text_reader.take_count();
                 for _ in 0..count {
                     self.text_reader.normal_mode_up();
@@ -3279,10 +3279,10 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('j') => {
+            KeyCode::Char('j') | KeyCode::Down => {
                 self.scroll_down();
             }
-            KeyCode::Char('k') => {
+            KeyCode::Char('k') | KeyCode::Up => {
                 self.scroll_up();
             }
             KeyCode::Char('h') => {

--- a/src/widget/navigation_panel/mod.rs
+++ b/src/widget/navigation_panel/mod.rs
@@ -224,11 +224,11 @@ impl NavigationPanel {
                 self.start_search();
                 None
             }
-            KeyCode::Char('j') => {
+            KeyCode::Char('j') | KeyCode::Down => {
                 self.handle_j();
                 None
             }
-            KeyCode::Char('k') => {
+            KeyCode::Char('k') | KeyCode::Up => {
                 self.move_selection_up();
                 None
             }


### PR DESCRIPTION
## Suggested change
Add support for `KeyCode::Down` and `KeyCode::Up` alongside 'j' and 'k' for movement commands in for scrolling chapter content and navigating up and down the chapter selection menu.

## Reason
I daily drive helix (nvim before that) and often use the arrow keys for navigation in addition to the idiomatic hjkl. I believe that this is common pattern among users who use alternate keyboard layouts like Colemak DH (what I use), Dvorak and so on. So I do think this will be useful addition. Plus this will be expected behavior for our estranged cousins (emacs users).

Thanks for building this lovely tool, I've been enjoying reading with it so far!