### PR TITLE
Added Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Bookokrat is a terminal-based EPUB reader with a split-view library and reader, 
 brew install bookokrat
 ```
 
+### Arch Linux
+
+Install from the [AUR](https://aur.archlinux.org/packages/bookokrat-bin) using your preferred AUR helper:
+
+```bash
+yay -S bookokrat-bin
+```
+
+or
+
+```bash
+paru -S bookokrat-bin
+```
+
 ### Pre-built Binaries (Linux)
 
 Download from [GitHub Releases](https://github.com/bugzmanov/bookokrat/releases):


### PR DESCRIPTION
## Summary
- Added installation instructions for Arch Linux users via the AUR package `bookokrat-bin` (I'm maintaining it)
- Instructions include examples for both yay and paru AUR helpers
- Positioned after Homebrew section for logical flow (macOS → Linux distros → general Linux)

## Changes
- Added new "Arch Linux" section in README.md Installation section
- Included link to AUR package page
- Added code examples for installation using yay and paru

## AUR Package
The AUR package is available at: https://aur.archlinux.org/packages/bookokrat-bin

This makes it easier for Arch Linux users to install bookokrat without manually downloading and extracting the binary.