### PR TITLE
feat: tmux DCS passthrough for kittyv2 PDF renderer

### DIFF
--- a/src/pdf/kittyv2/kgfx/mod.rs
+++ b/src/pdf/kittyv2/kgfx/mod.rs
@@ -10,7 +10,8 @@ pub(crate) use metrics::{record_shm_create, record_shm_unlink_error, record_shm_
 pub use pool::{RegionPool, pool};
 pub use protocol::{
     CHUNK_LIMIT, Compression, DeleteCommand, DeleteMode, DestCells, DirectTransmit, DisplayCommand,
-    Format, QueryCommand, Quiet, Response, SourceRect, TransmitCommand, parse_response,
+    Format, QueryCommand, Quiet, Response, SourceRect, TransmitCommand, is_tmux, parse_response,
+    set_tmux_mode,
 };
 pub use region::MemoryRegion;
 pub use tracker::{LifecycleTracker, tracker};


### PR DESCRIPTION
## Summary

- PDF rendering via Kitty graphics protocol now works inside tmux by wrapping APC sequences in DCS passthrough format
- Detects outer terminal (Ghostty/Kitty) when running inside tmux and enables the Kitty protocol accordingly
- Skips SHM and delete-range probes in tmux (incompatible with DCS passthrough) and auto-enables `allow-passthrough`

## Details

The `kittyv2` PDF renderer writes raw Kitty graphics APC sequences (`\x1b_G...\x1b\\`) directly to stdout. Inside tmux, these are consumed by tmux and never reach the outer terminal. This PR wraps them in DCS passthrough: `\x1bPtmux;\x1b\x1b_G...\x1b\x1b\\\x1b\\`.

### Changes

**`protocol.rs`** -- Global `AtomicBool` tmux flag, DCS constants, `write_apc_start`/`write_apc_end` helpers used by all 5 command types (TransmitCommand, DirectTransmit, DeleteCommand, QueryCommand, DisplayCommand).

**`terminal.rs`** -- `detect_outer_terminal_protocol_in_tmux()` checks `GHOSTTY_RESOURCES_DIR` and `KITTY_WINDOW_ID` env vars. Early returns in `probe_kitty_shm_support` and `probe_kitty_delete_range_support` for tmux.

**`main.rs`** -- Calls `set_tmux_mode(true)` and runs `tmux set -p allow-passthrough on` when inside tmux with a Kitty-capable outer terminal.

## Test plan

- [x] Tested PDF rendering inside tmux + Ghostty (Berserk manga volumes)
- [x] `cargo test` passes (43 passed, 3 pre-existing SVG snapshot failures)
- [x] Test outside tmux (should work unchanged)
- [x] Test EPUB inside tmux (vendored ratatui_image has its own tmux handling)

Closes #49