### PR TITLE
fix(features): included svg in default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ tempfile = "3.8"
 serial_test = "3.2"
 
 [features]
-default = ["pdf"]
+default = ["pdf", "svg"]
 test-utils = []
 serde = []
 pdf = ["mupdf", "flume", "wide", "lru", "rayon", "base64", "rdjvu"]


### PR DESCRIPTION
- Default build now enables the svg feature so EPUB inline SVGs can render.

<img width="1907" height="937" alt="image" src="https://github.com/user-attachments/assets/83f94ea3-27af-4753-8270-f27e71b18f46" />


<img width="1601" height="904" alt="image" src="https://github.com/user-attachments/assets/1ae50d6c-8934-43fe-9bd1-83b921a94324" />

<img width="1904" height="977" alt="image" src="https://github.com/user-attachments/assets/0f638001-1a4c-4956-ba74-a1603ab902a5" />
