### PR TITLE
Add markdown file and directory support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,7 @@ dependencies = [
  "open",
  "png",
  "pprof",
+ "pulldown-cmark",
  "rand",
  "ratatui",
  "rayon",
@@ -2662,6 +2663,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,6 +3874,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ thiserror = "1.0.59"
 flate2 = "1.0"
 png = "0.17"
 walkdir = "2.4"
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 
 # PDF rendering dependencies (optional, enabled with `pdf` feature)
 mupdf = { version = "0.6.0", default-features = false, features = ["svg", "system-fonts", "img"], optional = true }

--- a/src/book_manager.rs
+++ b/src/book_manager.rs
@@ -24,6 +24,7 @@ pub struct BookManager {
 pub enum BookFormat {
     Epub,
     Html,
+    Markdown,
     #[cfg(feature = "pdf")]
     Pdf,
 }
@@ -88,10 +89,23 @@ impl BookManager {
             .filter_map(|entry| {
                 let entry = entry.ok()?;
                 let path = entry.path();
+
+                // Check for markdown directories (e.g. wiki/)
+                if path.is_dir() && Self::is_markdown_directory(&path) {
+                    let path_str = path.to_str()?.to_string();
+                    let display_name = Self::extract_display_name(&path_str);
+                    return Some(BookInfo {
+                        path: path_str,
+                        display_name,
+                        format: BookFormat::Markdown,
+                    });
+                }
+
                 let extension = path.extension()?.to_str()?.to_lowercase();
                 let format = match extension.as_str() {
                     "epub" => Some(BookFormat::Epub),
                     "html" | "htm" => Some(BookFormat::Html),
+                    "md" | "markdown" => Some(BookFormat::Markdown),
                     #[cfg(feature = "pdf")]
                     "pdf" => Some(BookFormat::Pdf),
                     _ => None,
@@ -214,7 +228,16 @@ impl BookManager {
             }
         }
 
-        // For other files (like EPUB), remove the extension
+        // For directories (e.g. markdown wiki dirs), use the directory name
+        if path.is_dir() {
+            return path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+        }
+
+        // For other files (like EPUB, markdown), remove the extension
         path.file_stem()
             .unwrap_or_default()
             .to_string_lossy()
@@ -236,7 +259,11 @@ impl BookManager {
             return Err(format!("Book not found in managed list: {path}"));
         }
 
-        if self.is_html_file(path) {
+        if self.is_markdown_file(path) {
+            self.create_fake_epub_from_markdown(path)
+        } else if Self::is_markdown_directory(Path::new(path)) {
+            self.create_epub_from_markdown_dir(Path::new(path))
+        } else if self.is_html_file(path) {
             // For HTML files, create a fake EPUB
             self.create_fake_epub_from_html(path)
         } else if Self::is_epub_directory(Path::new(path)) {
@@ -624,6 +651,7 @@ impl BookManager {
                         BookFormat::Pdf => 0,
                         BookFormat::Epub => 1,
                         BookFormat::Html => 2,
+                        BookFormat::Markdown => 3,
                     }
                 };
                 type_order(&a.format)
@@ -658,10 +686,23 @@ impl BookManager {
     /// Detect format from file extension (for files not in the managed list)
     pub fn detect_format(path: &str) -> Option<BookFormat> {
         let path = Path::new(path);
+
+        // Check directories: exploded EPUB or markdown wiki
+        if path.is_dir() {
+            if Self::is_epub_directory(path) {
+                return Some(BookFormat::Epub);
+            }
+            if Self::is_markdown_directory(path) {
+                return Some(BookFormat::Markdown);
+            }
+            return None;
+        }
+
         let ext = path.extension()?.to_str()?.to_lowercase();
         match ext.as_str() {
             "epub" => Some(BookFormat::Epub),
             "html" | "htm" => Some(BookFormat::Html),
+            "md" | "markdown" => Some(BookFormat::Markdown),
             #[cfg(feature = "pdf")]
             "pdf" => Some(BookFormat::Pdf),
             _ => None,
@@ -670,6 +711,279 @@ impl BookManager {
 
     pub fn is_html_file(&self, path: &str) -> bool {
         Self::detect_format(path) == Some(BookFormat::Html)
+    }
+
+    pub fn is_markdown_file(&self, path: &str) -> bool {
+        let p = Path::new(path);
+        !p.is_dir() && Self::detect_format(path) == Some(BookFormat::Markdown)
+    }
+
+    fn is_markdown_directory(path: &Path) -> bool {
+        path.is_dir()
+            && std::fs::read_dir(path)
+                .ok()
+                .map(|entries| {
+                    entries.filter_map(Result::ok).any(|e| {
+                        e.path()
+                            .extension()
+                            .and_then(|ext| ext.to_str())
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+                    })
+                })
+                .unwrap_or(false)
+    }
+
+    fn markdown_to_html(markdown: &str) -> String {
+        use pulldown_cmark::{Options, Parser, html::push_html};
+
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_TABLES);
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+        options.insert(Options::ENABLE_TASKLISTS);
+
+        let parser = Parser::new_ext(markdown, options);
+        let mut html_output = String::new();
+        push_html(&mut html_output, parser);
+        html_output
+    }
+
+    fn extract_title_from_markdown(content: &str) -> Option<String> {
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if let Some(title) = trimmed.strip_prefix("# ") {
+                return Some(title.trim().to_string());
+            }
+        }
+        None
+    }
+
+    fn create_fake_epub_from_markdown(
+        &self,
+        path: &str,
+    ) -> Result<EpubDoc<BufReader<std::fs::File>>, String> {
+        let markdown_content = std::fs::read_to_string(path).map_err(|e| {
+            error!("Failed to read markdown file {path}: {e}");
+            format!("Failed to read markdown file: {e}")
+        })?;
+
+        let html_content = Self::markdown_to_html(&markdown_content);
+        self.create_minimal_epub_from_html(&html_content, path)
+    }
+
+    fn create_epub_from_markdown_dir(
+        &self,
+        dir: &Path,
+    ) -> Result<EpubDoc<BufReader<std::fs::File>>, String> {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+        use zip::write::FileOptions;
+
+        info!("Creating EPUB from markdown directory: {dir:?}");
+
+        // Collect markdown files with their titles
+        let mut md_files: Vec<(std::path::PathBuf, String, String)> = Vec::new(); // (path, stem, title)
+
+        let entries = std::fs::read_dir(dir)
+            .map_err(|e| format!("Failed to read directory: {e}"))?;
+
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+            {
+                let content = std::fs::read_to_string(&path)
+                    .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+                let stem = path
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                let title =
+                    Self::extract_title_from_markdown(&content).unwrap_or_else(|| stem.clone());
+                md_files.push((path, stem, title));
+            }
+        }
+
+        if md_files.is_empty() {
+            return Err("No markdown files found in directory".to_string());
+        }
+
+        // Sort: index-like files first (Home, README, index), then alphabetical
+        md_files.sort_by(|a, b| {
+            let priority = |name: &str| -> u8 {
+                match name.to_lowercase().as_str() {
+                    "home" | "readme" | "index" => 0,
+                    _ => 1,
+                }
+            };
+            priority(&a.1)
+                .cmp(&priority(&b.1))
+                .then_with(|| a.1.to_lowercase().cmp(&b.1.to_lowercase()))
+        });
+
+        let book_title = dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let dir_id = dir.to_string_lossy().replace('/', "_");
+
+        let temp_file =
+            NamedTempFile::new().map_err(|e| format!("Failed to create temp file: {e}"))?;
+        let temp_path = temp_file.path().to_path_buf();
+
+        {
+            let file = std::fs::File::create(&temp_path)
+                .map_err(|e| format!("Failed to create temp EPUB file: {e}"))?;
+            let mut zip = zip::ZipWriter::new(file);
+            let options =
+                FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+            // mimetype (must be first, uncompressed)
+            zip.start_file("mimetype", options)
+                .map_err(|e| format!("Failed to add mimetype: {e}"))?;
+            zip.write_all(b"application/epub+zip")
+                .map_err(|e| format!("Failed to write mimetype: {e}"))?;
+
+            // META-INF/container.xml
+            zip.start_file("META-INF/container.xml", options)
+                .map_err(|e| format!("Failed to add container.xml: {e}"))?;
+            zip.write_all(
+                br#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    <rootfiles>
+        <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+    </rootfiles>
+</container>"#,
+            )
+            .map_err(|e| format!("Failed to write container.xml: {e}"))?;
+
+            // Build manifest, spine, nav, and chapter files
+            let mut manifest_items = String::new();
+            let mut spine_items = String::new();
+            let mut nav_points = String::new();
+
+            for (i, (file_path, _stem, title)) in md_files.iter().enumerate() {
+                let chapter_id = format!("chapter{}", i + 1);
+                let chapter_file = format!("{chapter_id}.xhtml");
+
+                manifest_items.push_str(&format!(
+                    "        <item id=\"{chapter_id}\" href=\"{chapter_file}\" \
+                     media-type=\"application/xhtml+xml\"/>\n"
+                ));
+                spine_items
+                    .push_str(&format!("        <itemref idref=\"{chapter_id}\"/>\n"));
+
+                let escaped_title = title
+                    .replace('&', "&amp;")
+                    .replace('<', "&lt;")
+                    .replace('>', "&gt;");
+                nav_points.push_str(&format!(
+                    "        <navPoint id=\"{chapter_id}\" playOrder=\"{order}\">\n\
+                     \x20           <navLabel>\n\
+                     \x20               <text>{escaped_title}</text>\n\
+                     \x20           </navLabel>\n\
+                     \x20           <content src=\"{chapter_file}\"/>\n\
+                     \x20       </navPoint>\n",
+                    order = i + 1
+                ));
+
+                // Convert markdown to XHTML chapter
+                let md_content = std::fs::read_to_string(file_path)
+                    .map_err(|e| format!("Failed to read {}: {e}", file_path.display()))?;
+                let html_body = Self::markdown_to_html(&md_content);
+                let xhtml = format!(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                     <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \
+                     \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n\
+                     <html xmlns=\"http://www.w3.org/1999/xhtml\">\n\
+                     <head>\n    <title>{escaped_title}</title>\n</head>\n\
+                     <body>\n{html_body}\n</body>\n</html>"
+                );
+
+                zip.start_file(format!("OEBPS/{chapter_file}"), options)
+                    .map_err(|e| format!("Failed to add {chapter_file}: {e}"))?;
+                zip.write_all(xhtml.as_bytes())
+                    .map_err(|e| format!("Failed to write {chapter_file}: {e}"))?;
+            }
+
+            // content.opf
+            let escaped_book_title = book_title
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;");
+            let content_opf = format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                 <package xmlns=\"http://www.idpf.org/2007/opf\" \
+                 unique-identifier=\"bookid\" version=\"2.0\">\n\
+                 \x20   <metadata>\n\
+                 \x20       <dc:title xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\
+                 {escaped_book_title}</dc:title>\n\
+                 \x20       <dc:identifier xmlns:dc=\"http://purl.org/dc/elements/1.1/\" \
+                 id=\"bookid\">md-{dir_id}</dc:identifier>\n\
+                 \x20       <dc:language xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\
+                 en</dc:language>\n\
+                 \x20   </metadata>\n\
+                 \x20   <manifest>\n\
+                 {manifest_items}\
+                 \x20       <item id=\"ncx\" href=\"toc.ncx\" \
+                 media-type=\"application/x-dtbncx+xml\"/>\n\
+                 \x20   </manifest>\n\
+                 \x20   <spine toc=\"ncx\">\n\
+                 {spine_items}\
+                 \x20   </spine>\n\
+                 </package>"
+            );
+
+            zip.start_file("OEBPS/content.opf", options)
+                .map_err(|e| format!("Failed to add content.opf: {e}"))?;
+            zip.write_all(content_opf.as_bytes())
+                .map_err(|e| format!("Failed to write content.opf: {e}"))?;
+
+            // toc.ncx
+            let toc_ncx = format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                 <ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\">\n\
+                 \x20   <head>\n\
+                 \x20       <meta name=\"dtb:uid\" content=\"md-{dir_id}\"/>\n\
+                 \x20       <meta name=\"dtb:depth\" content=\"1\"/>\n\
+                 \x20       <meta name=\"dtb:totalPageCount\" content=\"0\"/>\n\
+                 \x20       <meta name=\"dtb:maxPageNumber\" content=\"0\"/>\n\
+                 \x20   </head>\n\
+                 \x20   <docTitle>\n\
+                 \x20       <text>{escaped_book_title}</text>\n\
+                 \x20   </docTitle>\n\
+                 \x20   <navMap>\n\
+                 {nav_points}\
+                 \x20   </navMap>\n\
+                 </ncx>"
+            );
+
+            zip.start_file("OEBPS/toc.ncx", options)
+                .map_err(|e| format!("Failed to add toc.ncx: {e}"))?;
+            zip.write_all(toc_ncx.as_bytes())
+                .map_err(|e| format!("Failed to write toc.ncx: {e}"))?;
+
+            zip.finish()
+                .map_err(|e| format!("Failed to finish ZIP: {e}"))?;
+        }
+
+        match EpubDoc::new(&temp_path) {
+            Ok(mut doc) => {
+                info!(
+                    "Successfully created EPUB from markdown directory: {dir:?} ({} chapters)",
+                    doc.get_num_chapters()
+                );
+                let _ = doc.set_current_chapter(0);
+                Ok(doc)
+            }
+            Err(e) => {
+                error!("Failed to open created EPUB from markdown directory: {e}");
+                Err(format!("Failed to open created EPUB: {e}"))
+            }
+        }
     }
 
     #[cfg(feature = "pdf")]
@@ -773,5 +1087,107 @@ mod tests {
 
         assert!(doc.get_num_chapters() >= 1);
         assert!(doc.get_current_str().is_some());
+    }
+
+    #[test]
+    fn detect_format_markdown_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let md_path = temp_dir.path().join("notes.md");
+        write_file(&md_path, "# Hello\n\nSome content.");
+
+        let format = BookManager::detect_format(md_path.to_str().unwrap());
+        assert_eq!(format, Some(BookFormat::Markdown));
+    }
+
+    #[test]
+    fn detect_format_markdown_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let wiki_dir = temp_dir.path().join("wiki");
+        fs::create_dir_all(&wiki_dir).unwrap();
+        write_file(&wiki_dir.join("Home.md"), "# Home\n\nWelcome.");
+        write_file(&wiki_dir.join("Guide.md"), "# Guide\n\nSteps.");
+
+        let format = BookManager::detect_format(wiki_dir.to_str().unwrap());
+        assert_eq!(format, Some(BookFormat::Markdown));
+    }
+
+    #[test]
+    fn load_single_markdown_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let md_path = temp_dir.path().join("readme.md");
+        write_file(
+            &md_path,
+            "# My Project\n\nA **bold** statement.\n\n## Section\n\n- item 1\n- item 2\n",
+        );
+
+        let manager = BookManager::new_with_directory(temp_dir.path().to_str().unwrap());
+        let mut doc = manager.load_epub(md_path.to_str().unwrap()).unwrap();
+
+        assert!(doc.get_num_chapters() >= 1);
+        let (content, _mime) = doc.get_current_str().unwrap();
+        assert!(content.contains("My Project"));
+        assert!(content.contains("<strong>bold</strong>"));
+    }
+
+    #[test]
+    fn load_markdown_directory_multi_chapter() {
+        let temp_dir = TempDir::new().unwrap();
+        let wiki_dir = temp_dir.path().join("wiki");
+        fs::create_dir_all(&wiki_dir).unwrap();
+        write_file(&wiki_dir.join("Home.md"), "# Home\n\nWelcome to the wiki.");
+        write_file(
+            &wiki_dir.join("Architecture.md"),
+            "# Architecture\n\nSystem design.",
+        );
+        write_file(
+            &wiki_dir.join("Getting-Started.md"),
+            "# Getting Started\n\nSetup steps.",
+        );
+
+        let manager = BookManager::new_with_directory(temp_dir.path().to_str().unwrap());
+        let wiki_path = wiki_dir.to_str().unwrap();
+        let mut doc = manager.load_epub(wiki_path).unwrap();
+
+        // Should have 3 chapters
+        assert_eq!(doc.get_num_chapters(), 3);
+
+        // First chapter should be Home (sorted first)
+        let (content, _mime) = doc.get_current_str().unwrap();
+        assert!(content.contains("Home"));
+        assert!(content.contains("Welcome to the wiki"));
+    }
+
+    #[test]
+    fn discover_markdown_files_in_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        write_file(&temp_dir.path().join("notes.md"), "# Notes");
+        write_file(&temp_dir.path().join("other.txt"), "not markdown");
+
+        let manager = BookManager::new_with_directory(temp_dir.path().to_str().unwrap());
+        let md_books: Vec<_> = manager
+            .books
+            .iter()
+            .filter(|b| b.format == BookFormat::Markdown)
+            .collect();
+        assert_eq!(md_books.len(), 1);
+        assert_eq!(md_books[0].display_name, "notes");
+    }
+
+    #[test]
+    fn discover_markdown_directory_in_parent() {
+        let temp_dir = TempDir::new().unwrap();
+        let wiki_dir = temp_dir.path().join("wiki");
+        fs::create_dir_all(&wiki_dir).unwrap();
+        write_file(&wiki_dir.join("Home.md"), "# Home");
+        write_file(&wiki_dir.join("Page.md"), "# Page");
+
+        let manager = BookManager::new_with_directory(temp_dir.path().to_str().unwrap());
+        let md_books: Vec<_> = manager
+            .books
+            .iter()
+            .filter(|b| b.format == BookFormat::Markdown)
+            .collect();
+        assert_eq!(md_books.len(), 1);
+        assert_eq!(md_books[0].display_name, "wiki");
     }
 }

--- a/src/book_manager.rs
+++ b/src/book_manager.rs
@@ -253,6 +253,8 @@ impl BookManager {
     }
 
     pub fn load_epub(&self, path: &str) -> Result<EpubDoc<BufReader<std::fs::File>>, String> {
+        // Normalize trailing slashes so "wiki/" matches "wiki" in the book list
+        let path = path.trim_end_matches('/');
         info!("Loading document from path: {path}");
 
         if !self.books.iter().any(|book| book.path == path) {

--- a/src/book_manager.rs
+++ b/src/book_manager.rs
@@ -757,6 +757,26 @@ impl BookManager {
         None
     }
 
+    /// Rewrite inter-file markdown links (e.g. `href="Getting-Started.md"`)
+    /// to point to the corresponding EPUB chapter file (e.g. `href="chapter3.xhtml"`).
+    fn rewrite_markdown_links(
+        html: &str,
+        link_map: &std::collections::HashMap<String, String>,
+    ) -> String {
+        use regex::Regex;
+        let re = Regex::new(r##"href="([^"#]+)(#[^"]*)?"##).unwrap();
+        re.replace_all(html, |caps: &regex::Captures| {
+            let target = &caps[1];
+            let anchor = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+            if let Some(chapter_file) = link_map.get(target) {
+                format!(r#"href="{chapter_file}{anchor}""#)
+            } else {
+                caps[0].to_string()
+            }
+        })
+        .to_string()
+    }
+
     fn create_fake_epub_from_markdown(
         &self,
         path: &str,
@@ -822,6 +842,14 @@ impl BookManager {
                 .cmp(&priority(&b.1))
                 .then_with(|| a.1.to_lowercase().cmp(&b.1.to_lowercase()))
         });
+
+        // Build link map: original filenames -> EPUB chapter filenames
+        let mut link_map = std::collections::HashMap::new();
+        for (i, (_path, stem, _title)) in md_files.iter().enumerate() {
+            let chapter_file = format!("chapter{}.xhtml", i + 1);
+            link_map.insert(format!("{stem}.md"), chapter_file.clone());
+            link_map.insert(format!("{stem}.markdown"), chapter_file.clone());
+        }
 
         let book_title = dir
             .file_name()
@@ -890,10 +918,13 @@ impl BookManager {
                     order = i + 1
                 ));
 
-                // Convert markdown to XHTML chapter
+                // Convert markdown to XHTML chapter, rewriting inter-file links
                 let md_content = std::fs::read_to_string(file_path)
                     .map_err(|e| format!("Failed to read {}: {e}", file_path.display()))?;
-                let html_body = Self::markdown_to_html(&md_content);
+                let html_body = Self::rewrite_markdown_links(
+                    &Self::markdown_to_html(&md_content),
+                    &link_map,
+                );
                 let xhtml = format!(
                     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
                      <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \
@@ -1171,6 +1202,42 @@ mod tests {
             .collect();
         assert_eq!(md_books.len(), 1);
         assert_eq!(md_books[0].display_name, "notes");
+    }
+
+    #[test]
+    fn markdown_dir_rewrites_internal_links() {
+        let temp_dir = TempDir::new().unwrap();
+        let wiki_dir = temp_dir.path().join("wiki");
+        fs::create_dir_all(&wiki_dir).unwrap();
+        write_file(
+            &wiki_dir.join("Home.md"),
+            "# Home\n\nSee [Architecture](Architecture.md) and [Guide](Guide.md#setup).",
+        );
+        write_file(
+            &wiki_dir.join("Architecture.md"),
+            "# Architecture\n\nBack to [Home](Home.md).",
+        );
+        write_file(&wiki_dir.join("Guide.md"), "# Guide\n\n## Setup\n\nSteps.");
+
+        let manager = BookManager::new_with_directory(temp_dir.path().to_str().unwrap());
+        let wiki_path = wiki_dir.to_str().unwrap();
+        let mut doc = manager.load_epub(wiki_path).unwrap();
+
+        // Home is chapter 1 (sorted first). Check its content has rewritten links.
+        let (content, _) = doc.get_current_str().unwrap();
+        // Architecture.md -> chapter2.xhtml, Guide.md#setup -> chapter3.xhtml#setup
+        assert!(
+            content.contains("chapter2.xhtml"),
+            "Architecture.md link should be rewritten to chapter2.xhtml"
+        );
+        assert!(
+            content.contains("chapter3.xhtml#setup"),
+            "Guide.md#setup link should be rewritten to chapter3.xhtml#setup"
+        );
+        assert!(
+            !content.contains("Architecture.md"),
+            "Original .md link should not remain"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn parse_args() -> Result<CliArgs> {
             "--zen-mode" => zen_mode = true,
             "--test-mode" => test_mode = true,
             "--help" | "-h" => {
-                println!("Usage: bookokrat [FILE.epub] [--zen-mode] [--test-mode]");
+                println!("Usage: bookokrat [FILE.epub|.pdf|.md|DIR] [--zen-mode] [--test-mode]");
                 std::process::exit(0);
             }
             "--version" | "-V" => {

--- a/src/main_app.rs
+++ b/src/main_app.rs
@@ -719,7 +719,7 @@ impl App {
             BookFormat::Pdf => {
                 self.load_pdf(&path_owned, self.test_mode)?;
             }
-            BookFormat::Epub | BookFormat::Html => {
+            BookFormat::Epub | BookFormat::Html | BookFormat::Markdown => {
                 self.load_epub(&path_owned, self.test_mode)?;
             }
         }

--- a/src/main_app.rs
+++ b/src/main_app.rs
@@ -710,7 +710,7 @@ impl App {
     pub fn open_book_for_reading_by_path(&mut self, path: &str) -> Result<()> {
         let format = BookManager::detect_format(path)
             .ok_or_else(|| anyhow::anyhow!("Unsupported file format: {}", path))?;
-        let path_owned = path.to_string();
+        let path_owned = path.trim_end_matches('/').to_string();
 
         self.save_bookmark_with_throttle(true);
 


### PR DESCRIPTION
## Summary

- Open single `.md` files as one-chapter books (e.g. `bookokrat README.md`)
- Open directories containing `.md` files as multi-chapter books with TOC (e.g. `bookokrat wiki/`)
- Markdown directories get proper chapter ordering: `Home.md`/`README.md`/`index.md` sorted first, then alphabetical
- Uses [pulldown-cmark](https://crates.io/crates/pulldown-cmark) for GFM-compatible conversion (tables, strikethrough, task lists)
- Markdown files and directories appear in the library browser alongside EPUBs and PDFs

## How it works

Follows the same pattern as the existing HTML file support — markdown content is converted to HTML via pulldown-cmark, then wrapped in a temporary EPUB that the existing rendering pipeline handles. For directories, each `.md` file becomes a chapter with a proper `toc.ncx` for navigation.

No changes to the rendering pipeline, text reader, or PDF infrastructure.

## Changes

- `Cargo.toml` — add `pulldown-cmark` dependency
- `src/book_manager.rs` — `BookFormat::Markdown` variant, format detection for `.md` files and markdown directories, `markdown_to_html()`, `create_fake_epub_from_markdown()` (single file), `create_epub_from_markdown_dir()` (multi-chapter), 6 new unit tests
- `src/main_app.rs` — route `BookFormat::Markdown` to the EPUB loader
- `src/main.rs` — update help text

## Test plan

- [x] All 385 existing tests pass (zero regressions)
- [x] 6 new unit tests covering: format detection for `.md` files, format detection for markdown directories, single file loading with HTML conversion verification, multi-chapter directory loading with chapter count and ordering verification, library discovery of `.md` files, library discovery of markdown directories
- [x] Manual testing: `bookokrat path/to/file.md` opens and renders correctly
- [x] Manual testing: `bookokrat path/to/wiki/` opens as multi-chapter book with TOC sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)