### PR TITLE
Add directory flag to set library location

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,10 @@ pub struct Cli {
     /// EPUB or PDF file to open
     pub file: Option<String>,
 
+    /// Directory to use as the library (defaults to current directory)
+    #[arg(long, short = 'd', conflicts_with = "file")]
+    pub directory: Option<String>,
+
     /// Open at a given chapter
     #[arg(long, requires = "file", conflicts_with = "page")]
     pub chapter: Option<usize>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ fn main() -> Result<()> {
         .and_then(|p| Path::new(p).parent())
         .filter(|p| !p.as_os_str().is_empty())
         .map(|p| p.to_path_buf())
+        .or_else(|| args.directory.as_deref().map(PathBuf::from))
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
     let lib_paths = library::resolve_library_paths(&library_dir);
@@ -332,7 +333,9 @@ fn main() -> Result<()> {
             } else {
                 parent.to_str()
             }
-        });
+        })
+        .or(args.directory.as_deref());
+        
     // In test mode: no auto-load, ephemeral bookmarks
     let auto_load_recent =
         should_auto_load_recent(args.file.as_deref(), args.test_mode, args.continue_reading);


### PR DESCRIPTION
Many people store their e-books on external drives or deep nested paths, and would either have to set up a shell function, or cd far from where they currently are to be able to use bookokrat in their e-book directory while passing through any flags they wish to.

The -c flag currently in bookokrat does work for opening the last read book, but if you go to the book list, it's still based on the current working directory and not where the opened book is from. I think that functionality is fine and shouldn't be changed, and it's better to add a specific flag for setting the directory.

Everything will work the same as usual, as the current working directory is still the default. This just allows explicitly setting where bookokrat opens.