### PR TITLE
Fix PDF normal mode `e` motion landing on next word's start

### DIFF
--- a/src/pdf/normal_mode.rs
+++ b/src/pdf/normal_mode.rs
@@ -336,6 +336,42 @@ impl NormalModeState {
         }
     }
 
+    /// Move to end of current word, or end of next word if already at a word's end
+    /// or on whitespace (vim `e` motion).
+    pub fn move_word_end(&mut self, line_bounds: &[LineBounds]) {
+        if !self.active {
+            return;
+        }
+
+        let mut line_idx = self.cursor.line_idx;
+        let mut idx = self.cursor.char_idx + 1;
+
+        loop {
+            let Some(line) = line_bounds.get(line_idx) else {
+                return;
+            };
+
+            while idx < line.chars.len() && line.chars[idx].c.is_whitespace() {
+                idx += 1;
+            }
+
+            if idx < line.chars.len() {
+                while idx + 1 < line.chars.len() && !line.chars[idx + 1].c.is_whitespace() {
+                    idx += 1;
+                }
+                self.cursor.line_idx = line_idx;
+                self.cursor.char_idx = idx;
+                return;
+            }
+
+            if line_idx >= line_bounds.len().saturating_sub(1) {
+                return;
+            }
+            line_idx += 1;
+            idx = 0;
+        }
+    }
+
     /// Move word backward
     pub fn move_word_backward(&mut self, line_bounds: &[LineBounds]) {
         if !self.active {

--- a/src/widget/pdf_reader/navigation.rs
+++ b/src/widget/pdf_reader/navigation.rs
@@ -745,7 +745,7 @@ impl PdfReaderState {
             }
             Action::WordEnd => {
                 let lb = self.current_line_bounds();
-                self.normal_mode.move_word_forward(&lb);
+                self.normal_mode.move_word_end(&lb);
                 InputResponse::handled(Some(self.normal_cursor_moved_action()))
             }
             Action::LineStart => {


### PR DESCRIPTION
## Summary
- In PDF normal mode, `e` (`Action::WordEnd`) was wired to `move_word_forward`, which is the `w` motion (jump to start of next word). As a result, `e` advanced to the next word's first character, and a visual-mode yank ending at `e` would include that character — e.g. yanking `"Contextual"` produced `"Contextual A"`.
- Added a proper `move_word_end` to `src/pdf/normal_mode.rs` that lands on the last non-whitespace char of the current/next word, spanning line breaks when the cursor is past the last word on the line. Updated the `Action::WordEnd` dispatch in `src/widget/pdf_reader/navigation.rs` to call it.
- EPUB normal mode already had a correct `find_word_end`; this PR is PDF-only.

## Test plan
- [x] Open a PDF, enter normal mode, press `e` repeatedly — cursor should land on the last char of each word, not the first char of the next word.
- [x] In visual mode, `ve` over a word followed by yank should copy exactly that word with no trailing word characters.
- [x] `e` at end of line should advance to the end of the first word on the next line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)