### PR TITLE
Fix scroll highlight at document edges

### DIFF
--- a/src/widget/text_reader/navigation.rs
+++ b/src/widget/text_reader/navigation.rs
@@ -169,10 +169,14 @@ impl crate::markdown_text_reader::MarkdownTextReader {
             self.dual_scroll(self.dual_half_step());
             return;
         }
+        let old_offset = self.scroll_offset;
         let scroll_amount = screen_height / 2;
         let max_offset = self.get_max_scroll_offset();
         self.scroll_offset = (self.scroll_offset + scroll_amount).min(max_offset);
-        self.highlight_visual_line = Some(Self::overlap_highlight_after_scroll_down());
+        self.highlight_visual_line = Some(Self::overlap_highlight_after_scroll_down(
+            screen_height,
+            self.scroll_offset.saturating_sub(old_offset),
+        ));
         self.highlight_end_time = Instant::now() + std::time::Duration::from_millis(150);
         // Clear current match when manually scrolling so next 'n' finds from new position
         if self.search_state.active && self.search_state.mode == SearchMode::NavigationMode {
@@ -205,18 +209,24 @@ impl crate::markdown_text_reader::MarkdownTextReader {
             self.dual_scroll(self.dual.page_height as isize);
             return;
         }
+        let old_offset = self.scroll_offset;
         let scroll_amount = screen_height.saturating_sub(1);
         let max_offset = self.get_max_scroll_offset();
         self.scroll_offset = (self.scroll_offset + scroll_amount).min(max_offset);
-        self.highlight_visual_line = Some(Self::overlap_highlight_after_scroll_down());
+        self.highlight_visual_line = Some(Self::overlap_highlight_after_scroll_down(
+            screen_height,
+            self.scroll_offset.saturating_sub(old_offset),
+        ));
         self.highlight_end_time = Instant::now() + std::time::Duration::from_millis(150);
         if self.search_state.active && self.search_state.mode == SearchMode::NavigationMode {
             self.search_state.current_match_index = None;
         }
     }
 
-    fn overlap_highlight_after_scroll_down() -> usize {
-        0
+    fn overlap_highlight_after_scroll_down(screen_height: usize, scroll_amount: usize) -> usize {
+        screen_height
+            .saturating_sub(scroll_amount)
+            .saturating_sub(1)
     }
 
     fn overlap_highlight_after_scroll_up(
@@ -752,5 +762,67 @@ mod tests {
 
         assert_eq!(reader.scroll_offset, 0);
         assert_eq!(reader.highlight_visual_line, Some(0));
+    }
+
+    #[test]
+    fn half_page_scroll_down_highlights_last_overlapping_line() {
+        let mut reader = MarkdownTextReader::new_without_image_support();
+        reader.total_wrapped_lines = 100;
+        reader.visible_height = 10;
+
+        reader.scroll_half_screen_down(10);
+
+        assert_eq!(reader.scroll_offset, 5);
+        assert_eq!(reader.highlight_visual_line, Some(4));
+    }
+
+    #[test]
+    fn half_page_scroll_down_near_end_highlights_actual_overlapping_line() {
+        let mut reader = MarkdownTextReader::new_without_image_support();
+        reader.total_wrapped_lines = 13;
+        reader.visible_height = 10;
+
+        reader.scroll_half_screen_down(10);
+
+        assert_eq!(reader.scroll_offset, 3);
+        assert_eq!(reader.highlight_visual_line, Some(6));
+    }
+
+    #[test]
+    fn half_page_scroll_up_near_top_highlights_actual_overlapping_line() {
+        let mut reader = MarkdownTextReader::new_without_image_support();
+        reader.total_wrapped_lines = 13;
+        reader.visible_height = 10;
+        reader.scroll_offset = 3;
+
+        reader.scroll_half_screen_up(10);
+
+        assert_eq!(reader.scroll_offset, 0);
+        assert_eq!(reader.highlight_visual_line, Some(3));
+    }
+
+    #[test]
+    fn full_page_scroll_down_near_end_highlights_actual_overlapping_line() {
+        let mut reader = MarkdownTextReader::new_without_image_support();
+        reader.total_wrapped_lines = 13;
+        reader.visible_height = 10;
+
+        reader.scroll_full_screen_down(10);
+
+        assert_eq!(reader.scroll_offset, 3);
+        assert_eq!(reader.highlight_visual_line, Some(6));
+    }
+
+    #[test]
+    fn full_page_scroll_up_near_top_highlights_actual_overlapping_line() {
+        let mut reader = MarkdownTextReader::new_without_image_support();
+        reader.total_wrapped_lines = 13;
+        reader.visible_height = 10;
+        reader.scroll_offset = 3;
+
+        reader.scroll_full_screen_up(10);
+
+        assert_eq!(reader.scroll_offset, 0);
+        assert_eq!(reader.highlight_visual_line, Some(3));
     }
 }


### PR DESCRIPTION
Fix page-up/page-down highlight placement when the scroll is clamped at the top or bottom of the document.

The highlight now uses the actual scroll delta after clamping, so partial page shifts still mark the real overlap boundary instead of assuming a full page move.

Covered cases:
 - half/full page down near the bottom of the document
 - half/full page up near the top of the document
 - partial-scroll edge cases where the move is smaller than the nominal page size 
 
 Improves fix for #156
 Related: 34547a04836812991b48919dd76a3f57cd06de02