### PR TITLE
change color of status line helpers in nord theme

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -434,7 +434,7 @@ static NORD_PALETTE: LazyLock<Base16Palette> = LazyLock::new(|| Base16Palette {
     base_00: smart_color(0x2E3440), // Polar Night darkest
     base_01: smart_color(0x3B4252),
     base_02: smart_color(0x434C5E),
-    base_03: smart_color(0x4C566A), // Polar Night lightest
+    base_03: smart_color(0x686F7A), // Polar Night lightest
     base_04: smart_color(0xD8DEE9), // Snow Storm
     base_05: smart_color(0xE5E9F0),
     base_06: smart_color(0xECEFF4), // Snow Storm brightest


### PR DESCRIPTION
Resolves issue #166 

Changes base_03 color to slightly lighter shade to improve readability

Cargo test produces one failed test that was failing prior to PR

failures:

---- every_pdf_default_binding_has_a_test stdout ----

thread 'every_pdf_default_binding_has_a_test' (2891988) panicked at tests/keybinding_actions_pdf.rs:459:9:
Untested PDF keybindings (1):
  pdf_normal            a → AddComment
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


<img width="1503" height="840" alt="Screenshot 2026-06-18 at 18 39 28" src="https://github.com/user-attachments/assets/da534a15-3b60-47e2-82f7-7c5d646e967f" />
