### PR TITLE
Docs: No crate-level documentation in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,46 @@
+//! # bookokrat
+//!
+//! A terminal-based EPUB, PDF, and DJVU book reader built with Rust.
+//!
+//! `bookokrat` provides a rich terminal UI for reading digital books, with
+//! support for EPUB, PDF, and DJVU formats. It renders formatted text,
+//! images, tables, and MathML directly in the terminal.
+//!
+//! ## Features
+//!
+//! - **EPUB** rendering with HTML-to-Markdown conversion and image display
+//! - **PDF** rendering via the `pdf` feature flag (uses `pdfium`)
+//! - **DJVU** support via external conversion
+//! - Configurable keybindings, themes, and color modes
+//! - Bookmarks, annotations, highlights, and reading history
+//! - Full-text search across book content
+//! - Table of contents navigation and jump list
+//! - Image popups with kitty/sixel protocol support
+//!
+//! ## Feature Flags
+//!
+//! | Feature      | Description                                    |
+//! |-------------|-----------------------------------------------|
+//! | `pdf`       | Enables PDF rendering support (requires pdfium)| |
+//! | `test-utils`| Exposes [`test_utils`] for integration tests   |
+//!
+//! ## Architecture
+//!
+//! The crate is organized into several top-level modules:
+//!
+//! - [`main_app`] — application state machine and event loop
+//! - [`parsing`] — HTML/EPUB/Markdown parsing and rendering
+//! - [`inputs`] — terminal input handling (keyboard, mouse, key sequences)
+//! - [`keybindings`] — configurable key-action mapping
+//! - [`book_manager`] — book loading, caching, and chapter management
+//! - [`library`] — book library management
+//! - [`theme`] — color themes and styling
+//! - [`search`] / [`search_engine`] — full-text search
+//! - [`annotations`], [`bookmarks`], [`marks`], [`comments`] — reading annotations
+//! - [`widget`] — TUI widgets (table of contents, book list, search, etc.)
+//! - [`images`] — image loading, storage, and display
+//! - [`terminal`] / [`terminal_overlay`] — terminal setup and overlay management
+//!
 // Export modules for use in tests
 pub mod annotations;
 pub mod book_manager;


### PR DESCRIPTION
## Problem

The crate is published on crates.io (Cargo.toml has `description`, `repository`, `keywords`, `categories`) but `src/lib.rs` has zero `//!` doc comments. This means the docs.rs landing page and `cargo doc` output are completely blank — no overview, no usage examples, no feature-flag explanation. For a library crate that downstream consumers (nix packages, homebrew formula, etc.) build against, this is the most visible documentation surface. Consumers have no idea what the public modules do, which features to enable, or how to use the exported API.


**Severity**: `high`
**File**: `src/lib.rs`

## Solution

Add crate-level documentation at the top of `src/lib.rs`:


## Changes

- `src/lib.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
