### PR TITLE
Android build fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ better-panic = "0.3"
 human-panic = "2.0"
 libc = "0.2"
 pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec"], optional = true }
-arboard = { version = "3.4", features = ["wayland-data-control"] }
+
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 tempfile = "3.8"
 # Restrict image formats to reduce build time; enable more via features below.
@@ -98,6 +98,9 @@ notify = { version = "8", optional = true }
 
 # DjVu rendering dependencies (optional, enabled with `djvu` feature)
 rdjvu = { package = "djvu", version = "0.1.0", optional = true }
+
+[target.'cfg(not(any(target_os = "android", target_os = "emscripten")))'.dependencies]
+arboard = { version = "3.4", features = ["wayland-data-control"] }
 
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.38.4", features = ["stdio", "termios", "fs"] }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -6,7 +6,10 @@ use std::sync::OnceLock;
 enum Provider {
     XClip,
     XSel,
+    TermuxClipboard,
+    #[cfg(not(target_os = "android"))]
     Arboard,
+    Noop,
 }
 
 static PROVIDER: OnceLock<Provider> = OnceLock::new();
@@ -39,7 +42,21 @@ fn detect() -> Provider {
         }
     }
 
-    Provider::Arboard
+    // Check for Termux clipboard (available through Termux:API)
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if binary_exists("termux-clipboard-set") {
+            return Provider::TermuxClipboard;
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        Provider::Arboard
+    }
+
+    // No clipboard tool available — clipboard operations will be no-ops
+    Provider::Noop
 }
 
 fn run_command(cmd: &str, args: &[&str], text: &str) -> Result<(), String> {
@@ -97,11 +114,17 @@ pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
     match provider {
         Provider::XClip => run_command("xclip", &["-selection", "clipboard"], text),
         Provider::XSel => run_command("xsel", &["-i", "-b"], text),
+        Provider::TermuxClipboard => run_command("termux-clipboard-set", &[], text),
+        #[cfg(not(target_os = "android"))]
         Provider::Arboard => {
             let mut cb = arboard::Clipboard::new()
                 .map_err(|e| format!("Failed to access clipboard: {e}"))?;
             cb.set_text(text)
                 .map_err(|e| format!("Failed to copy to clipboard: {e}"))
+        }
+        Provider::Noop => {
+            log::info!("Clipboard not available — no clipboard tool found");
+            Ok(())
         }
     }
 }

--- a/src/main_app.rs
+++ b/src/main_app.rs
@@ -700,6 +700,24 @@ impl App {
             book_manager.supports_graphics = startup_caps.supports_graphics;
             (book_manager, startup_caps)
         };
+        #[cfg(not(feature = "pdf"))]
+        let startup_caps = crate::terminal::TerminalCapabilities {
+            env: crate::terminal::TerminalEnv::read(),
+            kind: crate::terminal::TerminalKind::Unknown,
+            protocol: None,
+            supports_graphics: false,
+            supports_true_color: true,
+            supports_underline_color: true,
+            pdf: crate::terminal::PdfCapabilities {
+                supported: false,
+                blocked_reason: Some("PDF feature disabled".into()),
+                supports_comments: false,
+                supports_scroll_mode: false,
+                supports_normal_mode: false,
+                supports_kitty_shm: None,
+                supports_kitty_delete_range: None,
+            },
+        };
 
         let navigation_panel = NavigationPanel::new(&book_manager);
         #[cfg(any(test, feature = "test-utils"))]

--- a/src/main_app.rs
+++ b/src/main_app.rs
@@ -701,22 +701,16 @@ impl App {
             (book_manager, startup_caps)
         };
         #[cfg(not(feature = "pdf"))]
-        let startup_caps = crate::terminal::TerminalCapabilities {
-            env: crate::terminal::TerminalEnv::read(),
-            kind: crate::terminal::TerminalKind::Unknown,
-            protocol: None,
-            supports_graphics: false,
-            supports_true_color: true,
-            supports_underline_color: true,
-            pdf: crate::terminal::PdfCapabilities {
-                supported: false,
-                blocked_reason: Some("PDF feature disabled".into()),
-                supports_comments: false,
-                supports_scroll_mode: false,
-                supports_normal_mode: false,
-                supports_kitty_shm: None,
-                supports_kitty_delete_range: None,
-            },
+        let startup_caps = {
+            let mut caps = crate::terminal::detect_terminal();
+            caps.pdf.supported = false;
+            caps.pdf.blocked_reason = Some("PDF feature disabled".into());
+            caps.pdf.supports_comments = false;
+            caps.pdf.supports_scroll_mode = false;
+            caps.pdf.supports_normal_mode = false;
+            caps.pdf.supports_kitty_shm = None;
+            caps.pdf.supports_kitty_delete_range = None;
+            caps
         };
 
         let navigation_panel = NavigationPanel::new(&book_manager);


### PR DESCRIPTION
Fixes building bookokrat on Android (reported in issue #74 for Termux) by following the same approach Neovim uses for clipboard on Android.

**Changes (all target-gated or runtime-detected):**

1. **Cargo.toml**: `arboard` only on non-Android targets (it has no Android platform implementation).

2. **clipboard.rs**: Detection chain follows Neovim's clipboard provider pattern — try runtime tools in order: `xclip` → `xsel` → `termux-clipboard-set` (Termux:API) → `arboard` → noop. No compile-time assumptions about what platforms can or can't do clipboard.

3. **main_app.rs**: Provide `startup_caps` fallback when built without the `pdf` feature. Fixes a pre-existing compile error on `--no-default-features` builds (the variable was only defined inside the pdf feature gate but used unconditionally).

Tested: cargo check and cargo build --release --no-default-features on aarch64 Android (Termux).