### PR TITLE
Fit EPUB inline images to the reader viewport

### DIFF
--- a/src/widget/text_reader/images.rs
+++ b/src/widget/text_reader/images.rs
@@ -98,7 +98,7 @@ impl crate::markdown_text_reader::MarkdownTextReader {
                 let chapter_path = self.current_chapter_file.as_deref();
                 match book_images.get_image_size_with_context(&url, chapter_path) {
                     Some((w, h)) => {
-                        let height_cells = EmbeddedImage::height_in_cells(w, h);
+                        let height_cells = self.image_height_in_cells(w, h);
                         self.embedded_images.borrow_mut().insert(
                             url.clone(),
                             EmbeddedImage {
@@ -126,6 +126,7 @@ impl crate::markdown_text_reader::MarkdownTextReader {
     }
 
     pub fn preload_image_dimensions(&mut self, book_images: &BookImages) {
+        self.image_source = Some(book_images.clone());
         if let Some(doc) = self.markdown_document.clone() {
             self.background_loader.cancel_loading();
 
@@ -136,32 +137,129 @@ impl crate::markdown_text_reader::MarkdownTextReader {
             }
 
             debug!("Found {} images to load in document", images_to_load.len());
-            if !images_to_load.is_empty() {
-                if let Some(ref picker) = self.image_picker {
-                    let font_size = picker.font_size();
-                    let (cell_width, cell_height) = (font_size.0, font_size.1);
-                    let chapter_path = self.current_chapter_file.clone();
-                    self.background_loader.start_loading_with_context(
-                        images_to_load.clone(),
-                        book_images,
-                        cell_width,
-                        cell_height,
-                        chapter_path,
-                    );
-                    for (img_src, _) in images_to_load.iter() {
-                        if let Some(img_state) = self.embedded_images.borrow_mut().get_mut(img_src)
-                        {
-                            img_state.state = ImageLoadState::Loading;
-                        }
-                    }
-                } else {
-                    for (img, _) in images_to_load.iter() {
-                        if let Some(img_state) = self.embedded_images.borrow_mut().get_mut(img) {
-                            img_state.state = ImageLoadState::Unsupported;
-                        }
-                    }
+            if self.image_viewport.is_some() {
+                self.start_image_loading(images_to_load, book_images);
+            }
+        }
+    }
+
+    fn image_height_in_cells(&self, width: u32, height: u32) -> u16 {
+        let Some((viewport_width, viewport_height)) = self.image_viewport else {
+            return EmbeddedImage::height_in_cells(width, height);
+        };
+        let (cell_width, cell_height) = self
+            .image_picker
+            .as_ref()
+            .map(|picker| picker.font_size())
+            .unwrap_or((1, 2));
+
+        EmbeddedImage::height_in_viewport(
+            width,
+            height,
+            viewport_width,
+            viewport_height,
+            cell_width,
+            cell_height,
+        )
+    }
+
+    fn start_image_loading(
+        &mut self,
+        images_to_load: Vec<(String, u16)>,
+        book_images: &BookImages,
+    ) {
+        if images_to_load.is_empty() {
+            return;
+        }
+
+        let Some((cell_width, cell_height)) =
+            self.image_picker.as_ref().map(|picker| picker.font_size())
+        else {
+            for (img_src, _) in images_to_load {
+                if let Some(image) = self.embedded_images.borrow_mut().get_mut(&img_src) {
+                    image.state = ImageLoadState::Unsupported;
                 }
             }
+            return;
+        };
+
+        let chapter_path = self.current_chapter_file.clone();
+        if self.background_loader.start_loading_with_context(
+            images_to_load.clone(),
+            book_images,
+            cell_width,
+            cell_height,
+            chapter_path,
+        ) {
+            for (img_src, _) in images_to_load {
+                if let Some(image) = self.embedded_images.borrow_mut().get_mut(&img_src) {
+                    image.state = ImageLoadState::Loading;
+                }
+            }
+        }
+    }
+
+    pub fn prepare_images_for_viewport(&mut self, viewport_width: u16, viewport_height: u16) {
+        let viewport = (viewport_width, viewport_height);
+        if self.image_viewport == Some(viewport) {
+            return;
+        }
+        self.image_viewport = Some(viewport);
+
+        let (cell_width, cell_height) = self
+            .image_picker
+            .as_ref()
+            .map(|picker| picker.font_size())
+            .unwrap_or((1, 2));
+        let mut heights_changed = false;
+        let mut had_loading_images = false;
+
+        for image in self.embedded_images.borrow_mut().values_mut() {
+            if matches!(image.state, ImageLoadState::Failed { .. }) {
+                continue;
+            }
+            had_loading_images |= matches!(image.state, ImageLoadState::Loading);
+
+            let height_cells = EmbeddedImage::height_in_viewport(
+                image.width,
+                image.height,
+                viewport_width,
+                viewport_height,
+                cell_width,
+                cell_height,
+            );
+            if image.height_cells != height_cells {
+                image.height_cells = height_cells;
+                heights_changed = true;
+                if !matches!(image.state, ImageLoadState::Unsupported) {
+                    image.state = ImageLoadState::NotLoaded;
+                }
+            }
+        }
+
+        if heights_changed {
+            self.cache_generation += 1;
+        }
+        if heights_changed && had_loading_images {
+            self.background_loader.cancel_loading();
+            for image in self.embedded_images.borrow_mut().values_mut() {
+                if matches!(image.state, ImageLoadState::Loading) {
+                    image.state = ImageLoadState::NotLoaded;
+                }
+            }
+        }
+
+        let images_to_load = self
+            .embedded_images
+            .borrow()
+            .iter()
+            .filter_map(|(src, image)| {
+                matches!(image.state, ImageLoadState::NotLoaded)
+                    .then(|| (src.clone(), image.height_cells))
+            })
+            .collect();
+        if let Some(book_images) = self.image_source.clone() {
+            self.start_image_loading(images_to_load, &book_images);
         }
     }
 

--- a/src/widget/text_reader/mod.rs
+++ b/src/widget/text_reader/mod.rs
@@ -13,6 +13,7 @@ pub use types::*;
 
 use crate::comments::{BookComments, Comment};
 use crate::images::background_image_loader::BackgroundImageLoader;
+use crate::images::book_images::BookImages;
 use crate::markdown::Document;
 use crate::markdown_text_reader::text_selection::TextSelection;
 use crate::ratatui_image::{Resize, StatefulImage, ViewportOptions, picker::Picker};
@@ -21,7 +22,7 @@ use crate::terminal_overlay;
 use crate::theme::{Base16Palette, theme_background};
 use crate::types::LinkInfo;
 use crate::widget::hud_message::{HudMessage, HudMode};
-use image::{DynamicImage, GenericImageView};
+use image::GenericImageView;
 use log::{info, warn};
 use normal_mode::{CursorPosition, NormalModeState};
 use ratatui::{
@@ -166,6 +167,8 @@ pub struct MarkdownTextReader {
     last_rendered_image_rects: HashMap<String, Rect>,
     last_overlay_cleanup_key: Option<(usize, u64, u64, Rect)>,
     inline_images_suppressed: bool,
+    image_viewport: Option<(u16, u16)>,
+    image_source: Option<BookImages>,
     background_loader: BackgroundImageLoader,
 
     // Deferred node index to restore after rendering
@@ -348,6 +351,8 @@ impl MarkdownTextReader {
             last_rendered_image_rects: HashMap::new(),
             last_overlay_cleanup_key: None,
             inline_images_suppressed: false,
+            image_viewport: None,
+            image_source: None,
             background_loader: BackgroundImageLoader::new(),
             pending_node_restore: None,
             pending_node_highlight: None,
@@ -611,6 +616,8 @@ impl MarkdownTextReader {
                 None,
             )
         };
+
+        self.prepare_images_for_viewport(left_rect.width, left_rect.height);
 
         // Re-render when dimensions, focus, or cached content change
         if self.last_width != width
@@ -1261,7 +1268,7 @@ impl MarkdownTextReader {
                 let page = start / page_height;
                 let rect = if page % 2 == 0 { left_rect } else { right_rect };
                 let page_offset = start % page_height;
-                let image_cells = calculate_image_height_in_cells(image) as usize;
+                let image_cells = embedded_image.height_cells as usize;
                 let page_remaining = page_height.saturating_sub(page_offset);
                 let image_end_vrow = start_vrow + image_cells.min(page_remaining);
                 let viewport_top = self.dual.vtop;
@@ -1350,8 +1357,6 @@ impl MarkdownTextReader {
                             .min(area_height - image_screen_start);
 
                         if visible_image_height > 0 {
-                            let image_height_cells = calculate_image_height_in_cells(scaled_image);
-
                             let (render_y, render_height) = if image_top_clipped > 0 {
                                 (
                                     col_rect.y,
@@ -1750,6 +1755,7 @@ impl MarkdownTextReader {
         self.last_rendered_image_rects.clear();
         self.last_overlay_cleanup_key = None;
         self.inline_images_suppressed = false;
+        self.image_source = None;
         self.dual.clear();
     }
 
@@ -1849,11 +1855,6 @@ impl MarkdownTextReader {
     pub fn request_overlay_cleanup_on_next_frame(&mut self) {
         self.last_overlay_cleanup_key = None;
     }
-}
-
-fn calculate_image_height_in_cells(image: &DynamicImage) -> u16 {
-    let (width, height) = image.dimensions();
-    EmbeddedImage::height_in_cells(width, height)
 }
 
 #[cfg(test)]

--- a/src/widget/text_reader/types.rs
+++ b/src/widget/text_reader/types.rs
@@ -246,6 +246,33 @@ impl EmbeddedImage {
         }
     }
 
+    pub fn height_in_viewport(
+        width: u32,
+        height: u32,
+        viewport_width: u16,
+        viewport_height: u16,
+        cell_width: u16,
+        cell_height: u16,
+    ) -> u16 {
+        if width == 0 || height == 0 || cell_width == 0 || cell_height == 0 {
+            return Self::height_in_cells(width, height);
+        }
+
+        let available_height = viewport_height.saturating_sub(2).max(1);
+        let preferred_height = match Self::height_in_cells(width, height) {
+            IMAGE_HEIGHT_REGULAR => available_height,
+            compact_height => compact_height,
+        };
+        let width_limited_height =
+            (u64::from(viewport_width) * u64::from(cell_width) * u64::from(height)
+                / (u64::from(width) * u64::from(cell_height)))
+            .clamp(1, u64::from(u16::MAX)) as u16;
+
+        preferred_height
+            .min(available_height)
+            .min(width_limited_height)
+    }
+
     pub fn failed_img(img_src: &str, error_msg: &str) -> EmbeddedImage {
         let height_cells = EmbeddedImage::height_in_cells(200, 200);
         EmbeddedImage {


### PR DESCRIPTION
## Summary

- size regular EPUB inline images from the current reader column's available width and height
- preserve image aspect ratio using the terminal cell dimensions, while keeping the existing compact sizing for small and very wide images
- reload resized images only when a viewport change produces a different target height
- use the stored adaptive height consistently in both single-column and dual-column rendering

This is limited to EPUB inline images; PDF rendering and zoom settings are unchanged.

Fixes #181

## Testing

- `cargo fmt -- --check`
- `cargo check` and `cargo build --bin bookokrat` (with the pre-existing `src/clipboard.rs:55` missing-return compile error temporarily corrected locally; that unrelated correction is not included in this PR)
- `cargo test --test svg_snapshots test_image_inside_anchor_link_svg -- --exact`
- manual Konsole test at 132x44 with the 1353x1920 portrait cover from the issue scenario

The full SVG suite reported 71 passed, 8 existing snapshot mismatches, and 2 ignored. No golden snapshots were overwritten.